### PR TITLE
vertically align blocks

### DIFF
--- a/css/ext_iastate.css
+++ b/css/ext_iastate.css
@@ -567,6 +567,12 @@ img.staff_profile_smugmug {
 	line-height: 1.07273;
 }
 
+.vertical-alignment {
+	position: relative;
+	top: 50%;
+	transform: translateY(-50%);
+}
+
 .layout--background--red {
         background-color: #c8102e;
 }


### PR DESCRIPTION
add "vertical _alignment" as a layout builder style (type: component)

this will align content in blocks to the middle

example of vertical alignment added to the right block:

<img width="1280" alt="Screen Shot 2023-04-28 at 11 51 42 AM" src="https://user-images.githubusercontent.com/116776020/235208020-7e928ad1-deab-4ea2-890f-e82111b883a7.png">

<img width="1280" alt="Screen Shot 2023-04-28 at 11 48 57 AM" src="https://user-images.githubusercontent.com/116776020/235207977-2bf02289-aa63-4004-a953-9a017d93b98b.png">



