### PR TITLE
Shorten width on block bottom #2

### DIFF
--- a/css/county_iastate.css
+++ b/css/county_iastate.css
@@ -20,7 +20,6 @@ div.program_offering_blocks {
 }
 
 div.program_offering_blocks h2.isu-block-title.h4 {
-	border-bottom: 3px solid #f1be48;
 	color: #000000;
 }
 


### PR DESCRIPTION
Deleting this border bottom will make changes to ext_iastate.css work. Makes block title bottom short like ISU theme